### PR TITLE
Set externalDNS with explicit repository

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,17 @@ locals {
   external_dns_version = "2.6.4"
 }
 
+data "helm_repository" "stable" {
+  name = "stable"
+  url  = "https://kubernetes-charts.storage.googleapis.com"
+}
+
 resource "helm_release" "external_dns" {
-  name      = "external-dns"
-  chart     = "stable/external-dns"
-  namespace = "kube-system"
-  version   = local.external_dns_version
+  name       = "external-dns"
+  chart      = "external-dns"
+  repository = data.helm_repository.stable.metadata[0].name
+  namespace  = "kube-system"
+  version    = local.external_dns_version
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     domainFilters = lookup(var.cluster_r53_domainfilters, terraform.workspace, [var.cluster_domain_name])


### PR DESCRIPTION
As part of our Helm3 upgrade we need to use explicit repositories instead of writing on the name "stable/$chartName"

