### PR TITLE
Fix IRSA in EKS

### DIFF
--- a/irsa.tf
+++ b/irsa.tf
@@ -8,7 +8,7 @@ module "iam_assumable_role_admin" {
   role_name                     = "external-dns.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
   role_policy_arns              = [var.eks ? aws_iam_policy.external_dns.0.arn : ""]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:external-dns:external-dns"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:external-dns"]
 }
 
 resource "aws_iam_policy" "external_dns" {

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -14,7 +14,11 @@ domainFilters:
 rbac:
   create: true
   apiVersion: v1
-  serviceAccountName: default
+  serviceAccountName: external-dns
+%{ if eks ~}
+  serviceAccountAnnotations:
+    eks.amazonaws.com/role-arn: "${eks_service_account}"
+%{ endif ~}
 txtPrefix: "_external_dns."
 txtOwnerId: ${cluster}
 logLevel: info


### PR DESCRIPTION
ExternalDNS container wasn't getting the role from AWS because of lack of annotations and wrong namespace name, these changes fix the issue and also assign a new custom name for externalDNS's ServiceAccount 