### PR TITLE
Fixed conditional in order to avoid empty touple

### DIFF
--- a/irsa.tf
+++ b/irsa.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_admin" {
   create_role                   = var.eks ? true : false
   role_name                     = "external-dns.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
-  role_policy_arns              = [var.eks ? aws_iam_policy.external_dns.0.arn : ""]
+  role_policy_arns              = [var.eks && length(aws_iam_policy.external_dns) >= 1 ? aws_iam_policy.external_dns.0.arn : ""]
   oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:external-dns"]
 }
 


### PR DESCRIPTION
Otherwise, we face in EKS:

```
  on .terraform/modules/monitoring/prometheus.tf line 309, in module "iam_assumable_role_grafana_datasource":
 309:   role_policy_arns              = [var.eks ? aws_iam_policy.grafana_datasource.0.arn : "" ]
    |----------------
    | aws_iam_policy.grafana_datasource is empty tuple

The given key does not identify an element in this collection value.

```