### PR TITLE
External-dns Upgrade to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ module "external_dns" {
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(var.cluster_r53_resource_maps, terraform.workspace, ["arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.outputs.hosted_zone_id}"])
 
-  dependence_deploy = null_resource.deploy
   dependence_kiam   = helm_release.kiam
 
   # This section is for EKS
@@ -30,7 +29,6 @@ module "external_dns" {
 
   # EKS doesn't use KIAM but it is a requirement for the module.
   dependence_kiam   = ""
-  dependence_deploy = null_resource.deploy
 
   # This section is for EKS
   eks                         = true
@@ -57,7 +55,6 @@ module "external_dns" {
 | Name                        | Description                                                            | Type     | Default | Required |
 |-----------------------------|---------------------------------------------------------------         |:--------:|:-------:|:--------:|
 | dependence_kiam             | Kiam Dependence variable                                               | string   |         | yes      |
-| dependence_deploy           | Deploy (helm) dependence variable                                      | string   |         | yes      |
 | iam_role_nodes              | Nodes IAM role ARN in order to create the KIAM/Kube2IAM                | string   |         | yes      |
 | hostzone                    | To solve ACME Challenges. Scope should be limited to hostzone.         | string   |         | yes      |
 | cluster_domain_name         | Value used for externalDNS annotations                                 | string   |         | yes      |

--- a/main.tf
+++ b/main.tf
@@ -24,8 +24,7 @@ resource "helm_release" "external_dns" {
   })]
 
   depends_on = [
-    var.dependence_kiam,
-    var.dependence_deploy
+    var.dependence_kiam
   ]
 
 

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,16 @@
 locals {
-  external_dns_version = "2.6.4"
+  external_dns_version = "3.1.0"
 }
 
-data "helm_repository" "stable" {
-  name = "stable"
-  url  = "https://kubernetes-charts.storage.googleapis.com"
+data "helm_repository" "bitnami" {
+  name = "bitnami"
+  url  = "https://charts.bitnami.com/bitnami"
 }
 
 resource "helm_release" "external_dns" {
   name       = "external-dns"
   chart      = "external-dns"
-  repository = data.helm_repository.stable.metadata[0].name
+  repository = data.helm_repository.bitnami.metadata[0].name
   namespace  = "kube-system"
   version    = local.external_dns_version
 

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,5 +1,5 @@
 image:
-  tag: 0.5.17-debian-9-r0
+  tag: 0.7.1-debian-10-r68
 sources:
   - service
   - ingress
@@ -22,5 +22,6 @@ rbac:
 txtPrefix: "_external_dns."
 txtOwnerId: ${cluster}
 logLevel: info
+# policy: sync
 podAnnotations:
   iam.amazonaws.com/role: "${iam_role}"

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -22,6 +22,6 @@ rbac:
 txtPrefix: "_external_dns."
 txtOwnerId: ${cluster}
 logLevel: info
-# policy: sync
+policy: sync
 podAnnotations:
   iam.amazonaws.com/role: "${iam_role}"

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -14,9 +14,11 @@ domainFilters:
 rbac:
   create: true
   apiVersion: v1
-  serviceAccountName: external-dns
+serviceAccount:
+  create: true
+  name: external-dns
 %{ if eks ~}
-  serviceAccountAnnotations:
+  annotations:
     eks.amazonaws.com/role-arn: "${eks_service_account}"
 %{ endif ~}
 txtPrefix: "_external_dns."

--- a/variables.tf
+++ b/variables.tf
@@ -6,10 +6,6 @@
 #   description = "Prometheus module dependence in order to be executed."
 # }
 
-variable "dependence_deploy" {
-  description = "Deploy Module dependence in order to be executed (deploy resource is the helm init)"
-}
-
 variable "dependence_kiam" {
   description = "Kiam Module dependence in order to be executed"
 }


### PR DESCRIPTION
External-dns Upgrade to latest v3.1.0 using bitnami charts as stable chart is deprecated.

This is related to [1863](https://github.com/ministryofjustice/cloud-platform/issues/1863)