### PR TITLE
Update external-dns to latest

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "helm_release" "external_dns" {
   chart      = "external-dns"
   repository = "https://charts.bitnami.com/bitnami"
   namespace  = "kube-system"
-  version    = "5.0.4"
+  version    = "5.0.3"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     domainFilters = lookup(local.domainfilters, terraform.workspace, local.domainfilters["default"])

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "helm_release" "external_dns" {
   chart      = "external-dns"
   repository = "https://charts.bitnami.com/bitnami"
   namespace  = "kube-system"
-  version    = "4.10.0"
+  version    = "5.0.4"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     domainFilters = lookup(local.domainfilters, terraform.workspace, local.domainfilters["default"])


### PR DESCRIPTION
Mainly the upgrade is required because of https://github.com/kubernetes-sigs/external-dns/issues/1411 and the use of weight policies
 