### PR TITLE
Remove the pin for external-dns docker tag

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,5 +1,3 @@
-image:
-  tag: 0.7.1-debian-10-r68
 sources:
   - service
   - ingress


### PR DESCRIPTION
We shouldn't be pinning tag versions. We will use the one that comes with the helm chart