### PR TITLE
Add metrics and alerts to externalDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ module "external_dns" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
+| kubectl | 1.11.2 |
 
 ## Providers
 
@@ -63,6 +64,7 @@ module "external_dns" {
 |------|---------|
 | aws | n/a |
 | helm | n/a |
+| kubectl | 1.11.2 |
 
 ## Modules
 
@@ -79,6 +81,7 @@ module "external_dns" {
 | [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
 | [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) |
 | [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) |
+| [kubectl_manifest](https://registry.terraform.io/providers/gavinbunney/kubectl/1.11.2/docs/resources/manifest) |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -31,3 +31,7 @@ resource "helm_release" "external_dns" {
     ignore_changes = [keyring]
   }
 }
+
+resource "kubectl_manifest" "test" {
+    yaml_body = file("${path.module}/resources/alerts.yaml")
+}

--- a/resources/alerts.yaml
+++ b/resources/alerts.yaml
@@ -16,4 +16,4 @@ spec:
       labels:
         severity: warning
       annotations:
-        message: There're erros in external-dns service, it might lack of weight's annotations.
+        message: Errors found in external-dns service; This may be caused by an ingress rule lacking a weight annotation.

--- a/resources/alerts.yaml
+++ b/resources/alerts.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: external-dns-errors
+  namespace: kube-system
+  labels:
+    prometheus: cloud-platform
+spec:
+  groups:
+  - name: external-dns
+    rules:
+    - alert: ErrorsInExternalDNS
+      expr: external_dns_source_errors_total > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: There're erros in external-dns service, it might lack of weight's annotations.

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -25,3 +25,7 @@ logLevel: info
 policy: sync
 podAnnotations:
   iam.amazonaws.com/role: "${iam_role}"
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true

--- a/versions.tf
+++ b/versions.tf
@@ -7,5 +7,9 @@ terraform {
     helm = {
       source = "hashicorp/helm"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "1.11.2"
+    }
   }
 }


### PR DESCRIPTION
Used the _kubectl_ provider (instead of null resource) to add the `PrometheusRule`

The metrics are enabled directly by the helm chart.

The end to end was tested in test cluster: `cp-2307-1158`