### PR TITLE
Fix ErrorsInExternalDNS alert

### DIFF
--- a/resources/alerts.yaml
+++ b/resources/alerts.yaml
@@ -11,7 +11,7 @@ spec:
   - name: external-dns
     rules:
     - alert: ErrorsInExternalDNS
-      expr: external_dns_registry_errors_total > 0
+      expr: sum(increase(external_dns_registry_errors_total[2h])) > 5
       for: 5m
       labels:
         severity: warning


### PR DESCRIPTION
This alert was looking at total errors, so the alert is not cleared even after the issue is fixed.
Fix the alert to look for the last 2 hrs for more than 5 errors, as external-dns trigger alert every minute.