### PR TITLE
Upgrade external-dns to latest chart version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "helm_release" "external_dns" {
   chart      = "external-dns"
   repository = "https://charts.bitnami.com/bitnami"
   namespace  = "kube-system"
-  version    = "5.4.8"
+  version    = "6.5.2"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     domainFilters = lookup(local.domainfilters, terraform.workspace, local.domainfilters["default"])


### PR DESCRIPTION
This is to keep up to date and also fix the error:
Error: could not download chart: chart "external-dns" version "5.4.8" not found in
https://charts.bitnami.com/bitnami repository