### PR TITLE
Move to working version of external-dns

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "helm_release" "external_dns" {
   chart      = "external-dns"
   repository = "https://charts.bitnami.com/bitnami"
   namespace  = "kube-system"
-  version    = "6.5.2"
+  version    = "6.4.4"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     domainFilters = lookup(local.domainfilters, terraform.workspace, local.domainfilters["default"])


### PR DESCRIPTION
This is because using latest image, we have below error

Tried to delete resource record set [name='_external_dns.xxx.', type='TXT', set-identifier='xxx'] but it was not found

That caused Failure in zone