### PR TITLE
set regex list with exclusions and aws-zones-cache-duration

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,9 +1,9 @@
 sources:
   - service
   - ingress
-interval: 5m
+interval: 10m
 triggerLoopOnEvent: true
-aws-zones-cache-duration: 1h
+aws-zones-cache-duration: 3h
 regex-domain-filter:  /.*./g
 regex-domain-exclusion: /cp-.*|yy-.*/g
 provider: aws

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -3,6 +3,9 @@ sources:
   - ingress
 interval: 5m
 triggerLoopOnEvent: true
+aws-zones-cache-duration: 1h
+regex-domain-filter:  /.*./g
+regex-domain-exclusion: /cp-.*|yy-.*/g
 provider: aws
 aws:
   region: eu-west-2


### PR DESCRIPTION
Why:
[Investigate Route53 rate limit error on external-dns#4608](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4608)
With reference to errors in #lower-priority-alarms:
https://mojdt.slack.com/archives/C8QR5FQRX/p1689676793805339
Wait to see results in external-dns logs:
`kubectl logs external-dns-79b5dfc55f-rfcj9 -n kube-system  --context arn:aws:eks:eu-west-2:754256621582:cluster/cp-1207-0904`
and
`kubectl logs external-dns-79b5dfc55f-rfcj9 -n kube-system  --context arn:aws:eks:eu-west-2:754256621582:cluster/cp-1207-0904     | grep -i "throttli"`
over a number of days before merging please: