### PR TITLE
increase interval to 10m

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,7 +1,7 @@
 sources:
   - service
   - ingress
-interval: 5m
+interval: 10m
 triggerLoopOnEvent: true
 provider: aws
 aws:


### PR DESCRIPTION
Why[Investigate Route53 rate limit error on external-dns#4608](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4608)