### PR TITLE
set-aws-zones-cache-duration-throttling

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -3,6 +3,9 @@ sources:
   - ingress
 interval: 10m
 triggerLoopOnEvent: true
+aws-zones-cache-duration: 3h
+regex-domain-filter:  /.*./g
+regex-domain-exclusion: /cp-.*|yy-.*/g
 provider: aws
 aws:
   region: eu-west-2


### PR DESCRIPTION
Why:
[Investigate Route53 rate limit error on external-dns#4608](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4608)
With reference to [Throttling](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#throttling)
`regex-domain-filter:  /.*./g` this list all the domains
`regex-domain-exclusion: /cp-.*|yy-.*/g` - this will exclude the test domains "yy" and "cp" from that list

`aws-zones-cache-duration: 3h` cache zones managed by ExternalDNS, by setting a TTL
