### PR TITLE
Nginx-Default-Backend-Issue-revert-throttling-change-in-stages

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -3,7 +3,6 @@ sources:
   - ingress
 interval: 10m
 triggerLoopOnEvent: true
-aws-zones-cache-duration: 3h
 regex-domain-filter:  /.*./g
 regex-domain-exclusion: /cp-.*|yy-.*/g
 provider: aws


### PR DESCRIPTION
Why:
With reference to this issue [Nginx Default Backend Issue#4691](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4691)

and this one:

[Investigate Route53 rate limit error on external-dns#4608](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4608)

- Originally I introduced changes to the external_dn
(https://github.com/ministryofjustice/cloud-platform-terraform-external-dns/assets/6805936/e0bbf6de-9c89-4913-bca3-bbb80c3b1540)
s module to try to stop the throttling issues we experienced in [Investigate Route53 rate limit error on external-dns#4608](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4608) with reference to suggested changes here [throttling](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#throttling)
- However a few weeks later we had the above issue re the nginx default backend:
- -  specifically if you put in something like `https://asjdhak.apps.live.cloud-platform.service.justice.gov.uk/` it was going to a random page
- - I reverted the external dns changes:
- - - the same day the link was correctly going to 
![Screenshot 2023-08-21 at 11 27 24](https://github.com/ministryofjustice/cloud-platform-terraform-external-dns/assets/6805936/bf881e85-0130-4339-8ce4-a36b74ca853a)
 This may have been coincidental so:

reverting the 2 changes 1 at a time

ps - it’s not something that I/we can really test in a test cluster