### PR TITLE
revert to previous helm, image 0.13.4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "helm_release" "external_dns" {
   chart      = "external-dns"
   repository = "https://charts.bitnami.com/bitnami"
   namespace  = "kube-system"
-  version    = "6.34.1"
+  version    = "6.20.1"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     domainFilters = var.domain_filters


### PR DESCRIPTION
This PR reverts external-dns image from 0.14.0 to 0.13.4 to address hard failures on Route53 throttling and misconfiguration events.