### PR TITLE
Interval and cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ No outputs.
 | <a name="input_cluster_domain_name"></a> [cluster\_domain\_name](#input\_cluster\_domain\_name) | The cluster domain used for externalDNS | `any` | n/a | yes |
 | <a name="input_domain_filters"></a> [domain\_filters](#input\_domain\_filters) | n/a | `list(string)` | n/a | yes |
 | <a name="input_eks_cluster_oidc_issuer_url"></a> [eks\_cluster\_oidc\_issuer\_url](#input\_eks\_cluster\_oidc\_issuer\_url) | This is going to be used when we create the IAM OIDC role | `string` | `""` | no |
-| <a name="input_enable_test_cluster_filters"></a> [enable\_test\_cluster\_filters](#input\_enable\_test\_cluster\_filters) | Enable regex filters for ignoring test cluster domains | `bool` | `true` | no |
 | <a name="input_hostzones"></a> [hostzones](#input\_hostzones) | n/a | `list(string)` | n/a | yes |
+| <a name="input_is_live_cluster"></a> [is\_live\_cluster](#input\_is\_live\_cluster) | For assigning chart values based on the cluster type | `bool` | `true` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,8 @@ resource "helm_release" "external_dns" {
     domainFilters = var.domain_filters
 
     # For production clusters, we are excluding test cluster domains from being considered by external-dns
-    productionRegexDomainFilter = var.is_live_cluster ? "" : ".*"
-    productionRegexDomainExclusion = var.is_live_cluster ? "" : "cp-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$|yy-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$"
+    productionRegexDomainFilter = var.is_live_cluster ? ".*" : ""
+    productionRegexDomainExclusion = var.is_live_cluster ? "cp-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$|yy-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$" : ""
 
     # Set route53 sync interval and zone caching based on whether this is a production cluster or not
     sync_interval = var.is_live_cluster ? "10m" : "60m"

--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,8 @@ resource "helm_release" "external_dns" {
     domainFilters = var.domain_filters
 
     # For production clusters, we are excluding test cluster domains from being considered by external-dns
-    productionRegexDomainFilter = var.enable_test_cluster_filters ? ".*" : ""
-    productionRegexDomainExclusion = var.enable_test_cluster_filters ? "cp-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$|yy-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$" : ""
+    productionRegexDomainFilter = var.is_live_cluster ? "" : ".*"
+    productionRegexDomainExclusion = var.is_live_cluster ? "" : "cp-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$|yy-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$"
 
     # Set route53 sync interval and zone caching based on whether this is a production cluster or not
     sync_interval = var.is_live_cluster ? "10m" : "60m"

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,10 @@ resource "helm_release" "external_dns" {
     productionRegexDomainFilter = var.enable_test_cluster_filters ? ".*" : ""
     productionRegexDomainExclusion = var.enable_test_cluster_filters ? "cp-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$|yy-.*-.*\\.cloud-platform\\.service\\.justice\\.gov\\.uk$" : ""
 
+    # Set route53 sync interval and zone caching based on whether this is a production cluster or not
+    sync_interval = var.is_live_cluster ? "10m" : "60m"
+    aws_zone_cache_duration = var.is_live_cluster ? "0" : "3h"
+
     cluster             = terraform.workspace
     eks_service_account = module.iam_assumable_role_admin.this_iam_role_arn
   })]

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -1,13 +1,14 @@
 sources:
   - service
   - ingress
-interval: 10m
+interval: '${sync_interval}'
 triggerLoopOnEvent: true
 provider: aws
 aws:
   region: eu-west-2
   zoneType: public
   batchChangeSize: 4000
+  zonesCacheDuration: '${aws_zone_cache_duration}'
 domainFilters:
 %{ for d in domainFilters ~}
   - ${d}

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,9 @@ variable "enable_test_cluster_filters" {
   type        = bool
   default     = true
 }
+
+variable "is_live_cluster" {
+  description = "For assigning chart values based on the cluster type"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -16,12 +16,6 @@ variable "eks_cluster_oidc_issuer_url" {
   default     = ""
 }
 
-variable "enable_test_cluster_filters" {
-  description = "Enable regex filters for ignoring test cluster domains"
-  type        = bool
-  default     = true
-}
-
 variable "is_live_cluster" {
   description = "For assigning chart values based on the cluster type"
   type        = bool


### PR DESCRIPTION
This PR updates our external-dns module to put less strain on Route53 API by setting more sensible values for test clusters:

- polling loop interval from 10m to 60m
- add a zone caching duration of 3hrs (this is now explicitly passed in values, with live value respecting the existing default of `0` (caching off)

docs:
https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#throttling