### PR TITLE
chore: 🤖 increase cpu and mem values, set ephemeral storage

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -36,6 +36,10 @@ extraArgs:
   provider-cache-time: '15m'
 resources:
   requests:
-    memory: 256Mi
-  limits:
+    cpu: 500m
     memory: 512Mi
+    ephemeral-storage: 50Mi
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+    ephemeral-storage: 2Gi


### PR DESCRIPTION
ephemeral storage set to match default helm deployment value

relates to ministryofjustice/cloud-platform#6383
