### PR TITLE
fix: 🐛 roll back to previous external-dns release

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "helm_release" "external_dns" {
   chart      = "external-dns"
   repository = "https://charts.bitnami.com/bitnami"
   namespace  = "kube-system"
-  version    = "8.3.10"
+  version    = "6.20.1"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     domainFilters = var.domain_filters

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -32,14 +32,3 @@ metrics:
   serviceMonitor:
     enabled: true
 priorityClassName: system-cluster-critical
-extraArgs:
-  provider-cache-time: '15m'
-resources:
-  requests:
-    cpu: 500m
-    memory: 512Mi
-    ephemeral-storage: 50Mi
-  limits:
-    cpu: 2000m
-    memory: 2Gi
-    ephemeral-storage: 2Gi


### PR DESCRIPTION
reverting to `v0.13.4` to restore responsive R53 record updating