### PR TITLE
Increase resources and burstable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,12 +22,12 @@ resource "helm_release" "external_dns" {
   })]
 
   set {
-    name  = "global.resources.requests.cpu"
+    name  = "resources.requests.cpu"
     value = "200m" 
   }
 
   set {
-    name  = "global.resources.requests.memory"
+    name  = "resources.requests.memory"
     value = "1024Mi"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,16 @@ resource "helm_release" "external_dns" {
     eks_service_account = module.iam_assumable_role_admin.iam_role_arn
   })]
 
+  set {
+    name  = "global.resources.requests.cpu"
+    value = "200m" 
+  }
+
+  set {
+    name  = "global.resources.requests.memory"
+    value = "1024Mi"
+  }
+
   lifecycle {
     ignore_changes = [keyring]
   }


### PR DESCRIPTION
A change to the underlying Helm chart has been introduced between releases, regarding default resource allocation and limits for the pod (including `ephemeral-storage`)

https://github.com/bitnami/charts/blob/main/bitnami/external-dns/values.yaml#L1158

Previously external-dns did not set any requests/limits, here is some 3 hour usage stats:

CPU
![image](https://github.com/user-attachments/assets/69d3d7f2-25d8-4a21-82ee-8e36a5a4553b)

mem
![image](https://github.com/user-attachments/assets/8019d3b6-13b7-4e68-9374-df5c72a69482)

This PR provides a reasonable baseline resource allocation and leaves the pod qos `Burstable` for any possible spikes.

relates to ministryofjustice/cloud-platform#6509