### PR TITLE
chore: 🤖 update prefix for new TXT record pattern

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "helm_release" "external_dns" {
 
     cluster             = terraform.workspace
     eks_service_account = module.iam_assumable_role_admin.iam_role_arn
+    txtPrefix           = "_external_dns.%%{record_type}." 
   })]
 
   set {

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -23,7 +23,7 @@ serviceAccount:
   name: external-dns
   annotations:
     eks.amazonaws.com/role-arn: "${eks_service_account}"
-txtPrefix: "_external_dns."
+txtPrefix: "${txtPrefix}"
 txtOwnerId: ${cluster}
 logLevel: debug
 policy: sync


### PR DESCRIPTION
This PR updates our external-dns module to use the new `cname.` TXT record prefix formatting to resolve issue blocking upgrade.

relates to ministryofjustice/cloud-platform#6752