### PR TITLE
chore: 🤖 return external-dns loglevel to info

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -25,7 +25,7 @@ serviceAccount:
     eks.amazonaws.com/role-arn: "${eks_service_account}"
 txtPrefix: "${txtPrefix}"
 txtOwnerId: ${cluster}
-logLevel: debug
+logLevel: info
 policy: sync
 metrics:
   enabled: true


### PR DESCRIPTION
this has been left in debug level since the external-dns r53 migration work. No need for it any longer