### PR TITLE
chore: bump external dns to 9.0.3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "helm_release" "external_dns" {
   chart      = "external-dns"
   repository = "oci://registry-1.docker.io/bitnamicharts"
   namespace  = "kube-system"
-  version    = "8.7.2"
+  version    = "9.0.3"
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     domainFilters = var.domain_filters

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -35,7 +35,7 @@ priorityClassName: system-cluster-critical
 image:
   registry: docker.io
   repository: bitnamilegacy/external-dns
-  tag: 0.15.1-debian-12-r1
+  tag: 0.18.0-debian-12-r4
   pullPolicy: IfNotPresent
 
 
@@ -70,3 +70,6 @@ image:
 global:
   security:
     allowInsecureImages: true
+
+extraArgs:
+  exclude-record-types: AAAA


### PR DESCRIPTION
- bump external dns to version 0.18
- add extra argument to exclude IPv6 records
- relates to https://github.com/ministryofjustice/cloud-platform/issues/7777